### PR TITLE
fix: Filter messages that don't have a slash command

### DIFF
--- a/apps-script/incident-response/ChatApp.gs
+++ b/apps-script/incident-response/ChatApp.gs
@@ -157,7 +157,7 @@ function concatenateAllSpaceMessages_(spaceName) {
   // concatenating all the messages.
   let userMap = new Map();
   return messages
-    .filter(message => message.slashCommand !== undefined)
+    .filter(message => message.slashCommand === undefined)
     .map(message => `${getUserDisplayName_(userMap, message.sender.name)}: ${message.text}`)
     .join('\n');
 }


### PR DESCRIPTION
When generating the conversation history at the end of the incident, the filter was incorrectly keeping only the messages with slash commands. This fix inverts the logic so we keep the messages without slash commands, as desired.