### PR TITLE
chore: Update Rolodex Apps Script sample to use V8 engine

### DIFF
--- a/apps-script/dialogs/appsscript.json
+++ b/apps-script/dialogs/appsscript.json
@@ -2,6 +2,6 @@
   "timeZone": "America/Los_Angeles",
   "dependencies": {},
   "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "DEPRECATED_ES5",
+  "runtimeVersion": "V8",
   "chat": {}
 }


### PR DESCRIPTION
The corresponding [developer guide](https://developers.google.com/chat/how-tos/dialogs) was just updated to remove a note that said that the legacy script engine should be used. Accordingly, this sample should be updated to use the current V8 engine.