### PR TITLE
fix: failures of preview-link in Node.js runtime

### DIFF
--- a/node/preview-link/attach-card.js
+++ b/node/preview-link/attach-card.js
@@ -26,6 +26,7 @@ exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
     res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
+    return;
   }
 
   // Checks for the presence of event.message.matchedUrl and attaches a card
@@ -97,6 +98,7 @@ exports.onMessage = (req, res) => {
         },
       ],
     });
+    return;
   }
 
   // If the Chat app doesn’t detect a link preview URL pattern, it says so.

--- a/node/preview-link/attach-card.js
+++ b/node/preview-link/attach-card.js
@@ -24,15 +24,14 @@
  */
 exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
-    res.send(
+    return res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
-    return;
   }
 
   // Checks for the presence of event.message.matchedUrl and attaches a card
   // if present
   if (req.body.message.matchedUrl) {
-    res.json({
+    return res.json({
       'actionResponse': {'type': 'UPDATE_USER_MESSAGE_CARDS'},
       'cardsV2': [
         {
@@ -98,11 +97,10 @@ exports.onMessage = (req, res) => {
         },
       ],
     });
-    return;
   }
 
   // If the Chat app doesn’t detect a link preview URL pattern, it says so.
-  res.json({'text': 'No matchedUrl detected.'});
+  return res.json({'text': 'No matchedUrl detected.'});
 };
 
 // [END hangouts_chat_preview_link]

--- a/node/preview-link/preview-link.js
+++ b/node/preview-link/preview-link.js
@@ -24,9 +24,8 @@
  */
 exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
-    res.send(
+    return res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
-    return;
   }
 
   // Respond to button clicks on attached cards
@@ -39,20 +38,18 @@ exports.onMessage = (req, res) => {
       'UPDATE_MESSAGE';
 
     if (req.body.action.actionMethodName === 'assign') {
-      res.json(createMessage(actionResponseType, 'You'));
-      return;
+      return res.json(createMessage(actionResponseType, 'You'));
     }
   }
 
   // Checks for the presence of event.message.matchedUrl and attaches a card
   // if present
   if (req.body.message.matchedUrl) {
-    res.json(createMessage());
-    return;
+    return res.json(createMessage());
   }
 
   // If the Chat app doesn’t detect a link preview URL pattern, it says so.
-  res.json({'text': 'No matchedUrl detected.'});
+  return res.json({'text': 'No matchedUrl detected.'});
 };
 
 /**

--- a/node/preview-link/preview-link.js
+++ b/node/preview-link/preview-link.js
@@ -26,12 +26,7 @@ exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
     res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
-  }
-
-  // Checks for the presence of event.message.matchedUrl and attaches a card
-  // if present
-  if (req.body.message.matchedUrl) {
-    res.json(createMessage());
+    return;
   }
 
   // Respond to button clicks on attached cards
@@ -45,7 +40,15 @@ exports.onMessage = (req, res) => {
 
     if (req.body.action.actionMethodName === 'assign') {
       res.json(createMessage(actionResponseType, 'You'));
+      return;
     }
+  }
+
+  // Checks for the presence of event.message.matchedUrl and attaches a card
+  // if present
+  if (req.body.message.matchedUrl) {
+    res.json(createMessage());
+    return;
   }
 
   // If the Chat app doesn’t detect a link preview URL pattern, it says so.

--- a/node/preview-link/sender-type.js
+++ b/node/preview-link/sender-type.js
@@ -26,6 +26,7 @@ exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
     res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
+    return;
   }
 
   // Respond to button clicks on attached cards

--- a/node/preview-link/sender-type.js
+++ b/node/preview-link/sender-type.js
@@ -24,9 +24,8 @@
  */
 exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
-    res.send(
+    return res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
-    return;
   }
 
   // Respond to button clicks on attached cards
@@ -38,7 +37,7 @@ exports.onMessage = (req, res) => {
       'UPDATE_USER_MESSAGE_CARDS' :
       'UPDATE_MESSAGE';
 
-    res.json({
+    return res.json({
       'actionResponse': {
 
         // Dynamically returns the correct actionResponse type.

--- a/node/preview-link/simple-text-message.js
+++ b/node/preview-link/simple-text-message.js
@@ -26,6 +26,7 @@ exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
     res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
+    return;
   }
 
   // Checks for the presence of event.message.matchedUrl and responds with a
@@ -35,6 +36,7 @@ exports.onMessage = (req, res) => {
       'text': 'req.body.message.matchedUrl.url: ' +
         req.body.message.matchedUrl.url,
     });
+    return;
   }
 
   // If the Chat app doesn’t detect a link preview URL pattern, it says so.

--- a/node/preview-link/simple-text-message.js
+++ b/node/preview-link/simple-text-message.js
@@ -24,23 +24,21 @@
  */
 exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
-    res.send(
+    return res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
-    return;
   }
 
   // Checks for the presence of event.message.matchedUrl and responds with a
   // text message if present
   if (req.body.message.matchedUrl) {
-    res.json({
+    return res.json({
       'text': 'req.body.message.matchedUrl.url: ' +
         req.body.message.matchedUrl.url,
     });
-    return;
   }
 
   // If the Chat app doesn’t detect a link preview URL pattern, it says so.
-  res.json({'text': 'No matchedUrl detected.'});
+  return res.json({'text': 'No matchedUrl detected.'});
 };
 
 // [END hangouts_chat_preview_link]

--- a/node/preview-link/update-card.js
+++ b/node/preview-link/update-card.js
@@ -26,6 +26,7 @@ exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
     res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
+    return;
   }
 
   // Respond to button clicks on attached cards

--- a/node/preview-link/update-card.js
+++ b/node/preview-link/update-card.js
@@ -24,9 +24,8 @@
  */
 exports.onMessage = (req, res) => {
   if (req.method === 'GET' || !req.body.message) {
-    res.send(
+    return res.send(
       'Hello! This function is meant to be used in a Google Chat Space.');
-    return;
   }
 
   // Respond to button clicks on attached cards
@@ -39,7 +38,7 @@ exports.onMessage = (req, res) => {
       'UPDATE_MESSAGE';
 
     if (req.body.action.actionMethodName === 'assign') {
-      res.json({
+      return res.json({
         'actionResponse': {
 
           // Dynamically returns the correct actionResponse type.


### PR DESCRIPTION
* Only send one response in all cases.
* Filter card click events before matched URLs to avoid unreachable code.