### PR TITLE
fix: Use readonly OAuth scope in the AI Knowledge Assistant app

### DIFF
--- a/node/ai-knowledge-assistant/services/user-auth.js
+++ b/node/ai-knowledge-assistant/services/user-auth.js
@@ -29,7 +29,7 @@ const { FirestoreService } = require('./firestore-service');
 const keys = require('../client_secrets.json').web;
 
 // Define the app's authorization scopes.
-const scopes = ['https://www.googleapis.com/auth/chat.messages'];
+const scopes = ['https://www.googleapis.com/auth/chat.messages.readonly'];
 
 /**
  * Creates a new OAuth2 client with the configured keys.


### PR DESCRIPTION
The AI Knowledge Assistant uses the Chat API with user credentials to list the messages in a space. It only needs the scope chat.messages.readonly to list the messages; it doesn't need a scope with write permission.