### PR TITLE
feat: Add Java User Authorization App sample

### DIFF
--- a/java/user-auth-app/.gcloudignore
+++ b/java/user-auth-app/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+README.md
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+# Target directory for maven builds
+target/

--- a/java/user-auth-app/.gitignore
+++ b/java/user-auth-app/.gitignore
@@ -1,0 +1,2 @@
+**/client_secrets.json
+target/

--- a/java/user-auth-app/README.md
+++ b/java/user-auth-app/README.md
@@ -1,0 +1,141 @@
+# Google Chat User Authorization App
+
+This sample demonstrates how to create a Google Chat app that requests
+authorization from the user to make calls to Chat API on their behalf. The first
+time the user interacts with the app, it requests offline OAuth tokens for the
+user and saves them to a Firestore database. If the user interacts with the app
+again, the saved tokens are used so the app can call Chat API on behalf of the
+user without asking for authorization again. Once saved, the OAuth tokens could
+even be used to call Chat API without the user being present.
+
+This app is built using Java 17 and
+[Spring Boot](https://spring.io/projects/spring-boot) on Google App Engine
+(Standard Environment) and leverages Google's OAuth2 for authorization and
+Firestore for data storage.
+
+**Key Features:**
+
+* **User Authorization:** Securely requests user consent to call Chat API with
+  their credentials.
+* **Chat API Integration:** Calls Chat API to post messages on behalf of the
+  user.
+* **Google Chat Integration:**  Responds to DMs or @mentions in Google Chat. If
+  necessary, request configuration to start an OAuth authorization flow.
+* **App Engine Deployment:**  Provides step-by-step instructions for deploying
+  to App Engine.
+* **Cloud Firestore:** Stores user tokens in a Firestore database.
+
+## Prerequisites
+
+* **JDK 17:**  [Download](https://openjdk.org/projects/jdk/17/)
+* **Google Cloud SDK:**  [Install](https://cloud.google.com/sdk/docs/install)
+* **Google Cloud Project:**  [Create](https://console.cloud.google.com/projectcreate)
+
+##  Deployment Steps
+
+1. **Set up your development environment:**
+
+   * Follow the steps in
+     [Setting Up Your Development Environment](https://cloud.google.com/appengine/docs/standard/setting-up-environment?tab=java)
+     to install Java and the Google Cloud SDK.
+
+   * Follow the steps in
+     [Using Maven and the App Engine Plugin](https://cloud.google.com/appengine/docs/standard/java-gen2/using-maven)
+     to install Maven.
+
+1. **Enable APIs:**
+
+   * Enable the Cloud Firestore and Google Chat APIs using the
+     [console](https://console.cloud.google.com/apis/enableflow?apiid=firestore.googleapis.com,chat.googleapis.com)
+     or gcloud:
+
+     ```bash
+     gcloud services enable firestore.googleapis.com chat.googleapis.com
+     ```
+
+1. **Initiate Deployment to App Engine:**
+
+   * Go to [App Engine](https://console.cloud.google.com/appengine) and
+     initialize an application.
+
+   * Deploy the User Authorization app to App Engine:
+
+     ```bash
+     mvn clean package appengine:deploy -Dapp.deploy.projectId=YOUR_PROJECT_ID
+     ```
+
+     Replace `YOUR_PROJECT_ID` with your Google Cloud Project ID.
+
+1. **Create and Use OAuth Client ID:**
+
+   * Get the app hostname:
+
+     ```bash
+     gcloud app describe | grep defaultHostname
+     ```
+
+   * In your Google Cloud project, go to
+     [APIs & Services > Credentials](https://console.cloud.google.com/apis/credentials).
+   * Click `Create Credentials > OAuth client ID`.
+   * Select `Web application` as the application type.
+   * Add `<hostname from the previous step>/oauth2` to `Authorized redirect URIs`.
+   * Download the JSON file, rename it to `client_secrets.json`, and copy it to
+     the `src/main/resources/` subdirectory in your project directory.
+   * Redeploy the app with the file `client_secrets.json`:
+
+     ```bash
+     mvn clean package appengine:deploy -Dapp.deploy.projectId=YOUR_PROJECT_ID
+     ```
+
+     Replace `YOUR_PROJECT_ID` with your Google Cloud Project ID.
+
+1. **Create a Firestore Database:**
+
+   *  Create a Firestore database in native mode named `auth-data` using the
+      [console](https://console.cloud.google.com/firestore) or gcloud:
+
+      ```bash
+      gcloud firestore databases create \
+      --database=auth-data \
+      --location=REGION \
+      --type=firestore-native
+      ```
+
+      Replace `REGION` with a
+      [Firestore location](https://cloud.google.com/firestore/docs/locations#types)
+      such as `nam5` or `eur3`.
+
+## Create the Google Chat app
+
+* Go to
+  [Google Chat API](https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat)
+  and click `Configuration`.
+* In **App name**, enter `User Auth App`.
+* In **Avatar URL**, enter `https://developers.google.com/chat/images/quickstart-app-avatar.png`.
+* In **Description**, enter `Quickstart app`.
+* Under Functionality, select **Receive 1:1 messages** and
+  **Join spaces and group conversations**.
+* Under **Connection settings**, select **HTTP endpoint URL** and enter your App
+  Engine app's URL (obtained in the previous deployment steps) without the
+  trailing `/`.
+* In **Authentication Audience**, select **HTTP endpoint URL**.
+* Under **Visibility**, select **Make this Google Chat app available to specific
+  people and groups in your domain** and enter your email address.
+* Click **Save**.
+
+The Chat app is ready to receive and respond to messages on Chat.
+
+## Interact with the App
+
+* Add the app to a Google Chat space.
+* @mention the app.
+* Follow the authorization link to grant the app access to your account.
+* Once authorization is complete, the app will post a message to the space using
+  your credentials.
+* If you @mention the app again, it will post a new message to the space with
+  your credentials using the saved tokens, without asking for authorization again.
+
+## Related Topics
+
+* [Authenticate and authorize as a Google Chat user](https://developers.google.com/workspace/chat/authenticate-authorize-chat-user)
+* [Receive and respond to user interactions](https://developers.google.com/workspace/chat/receive-respond-interactions)

--- a/java/user-auth-app/pom.xml
+++ b/java/user-auth-app/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>user-auth-app</name>
+
+  <groupId>com.google.chat</groupId>
+  <artifactId>user-auth-app</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.2.3</version>
+      <exclusions>
+        <!-- Exclude the Tomcat dependency -->
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jetty</artifactId>
+      <version>3.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.17.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>33.4.0-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.29.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-firestore</artifactId>
+      <version>3.30.2</version>
+    </dependency>
+
+    <!-- Google OAuth2 Client Library -->
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+      <version>1.30.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.30.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client-jetty</artifactId>
+      <version>1.37.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>2.7.1</version>
+    </dependency>
+
+    <!-- Google Cloud Chat library -->
+    <!-- Used for instantiating Google Chat API protos -->
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-chat-v1</artifactId>
+      <version>0.19.0</version>
+    </dependency>
+    <!-- Used for creating Chat Service Client for making Google Chat API calls -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-chat</artifactId>
+      <version>0.19.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-bom</artifactId>
+      <version>2.59.0</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>3.2.3</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>2.7.0</version>
+        <configuration>
+          <version>GCLOUD_CONFIG</version>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/java/user-auth-app/src/main/appengine/app.yaml
+++ b/java/user-auth-app/src/main/appengine/app.yaml
@@ -1,0 +1,20 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: java17
+instance_class: F1
+
+# Explicitly set the memory limit and maximum heap size for the Spring Boot app
+env_variables:
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAM=256m -XX:ActiveProcessorCount=2 -Xmx32m"

--- a/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/App.java
+++ b/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/App.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.chat.userAuthApp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.chat.v1.Message;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+/**
+ * The main class for the project, which implements a SpringBoot application
+ * and REST controller to listen to HTTP requests from Chat events and the OAuth
+ * flow callback.
+ */
+@SpringBootApplication
+@RestController
+public class App {
+  private static final Logger logger = Logger.getLogger(App.class.getName());
+
+  /** Executes the SpringBoot application. */
+  public static void main(String[] args) {
+    SpringApplication.run(App.class, args);
+  }
+
+  private final OauthFlow oauthFlow;
+  private final UserAuthPost userAuthPost;
+
+  /** Initializes the app dependencies. */
+  public App(OauthFlow oauthFlow, UserAuthPost userAuthPost) {
+    this.oauthFlow = oauthFlow;
+    this.userAuthPost = userAuthPost;
+  }
+
+  /** App route that handles unsupported GET requests. */
+  @GetMapping("/")
+  public String onGet() {
+    return "Hello! This endpoint is meant to be called from Google Chat.";
+  }
+
+  /**
+   * App route that handles callback requests from the OAuth authorization flow.
+   * The handler exhanges the code received from the OAuth2 server with a set of
+   * credentials, stores the authentication and refresh tokens in the database,
+   * and redirects the request to the config complete URL from the request.
+   */
+  @GetMapping("/oauth2")
+  public RedirectView onOauthCallback(
+      @RequestParam("error") Optional<String> error,
+      @RequestParam("code") Optional<String> code,
+      @RequestParam("state") Optional<String> state) throws Exception {
+    String redirectUrl = oauthFlow.oauth2callback(error, code, state);
+    return new RedirectView(redirectUrl);
+  }
+
+  /** App route that responds to interaction events from Google Chat. */
+  @PostMapping("/")
+  public String onEvent(
+      @RequestHeader("authorization") String authorization,
+      @RequestBody JsonNode event) throws Exception {
+    if (!RequestVerifier.verifyGoogleChatRequest(authorization)) {
+      return "Hello! This endpoint is meant to be called from Google Chat.";
+    }
+    try {
+      return toJson(userAuthPost.postWithUserCredentials(event));
+    } catch (Exception e) {
+      logger.log(
+          Level.SEVERE, "Error calling Chat API: " + e.getMessage(), e);
+      return toJson(
+          Message
+              .newBuilder()
+              .setText("Error calling Chat API: " + e.getMessage())
+              .build());
+    }
+  }
+
+  /** Converts a protobuf Message to its JSON representation. */
+  private static String toJson(com.google.protobuf.Message message) {
+    try {
+      return JsonFormat.printer().print(message);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(
+          "Application error: cannot convert message to JSON.", e);
+    }
+  }
+}

--- a/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/FirestoreService.java
+++ b/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/FirestoreService.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.chat.userAuthApp;
+
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+/** Service that saves and loads OAuth user tokens on Firestore. */
+@Repository
+public class FirestoreService {
+  // The prefix used by the Google Chat API in the User resource name.
+  private static final String USERS_PREFIX = "users/";
+
+  // The name of the users collection in the database.
+  private static final String USERS_COLLECTION = "users";
+
+  private final Firestore db;
+
+  /**
+   * Initializes the Firestore database using Application Default Credentials.
+   */
+  public FirestoreService() {
+    FirestoreOptions firestoreOptions =
+        FirestoreOptions.newBuilder().setDatabaseId("auth-data").build();
+    db = firestoreOptions.getService();
+  }
+
+  /**
+   * Stores the user's access and refresh tokens in Firestore.
+   * @param userName the user's name
+   * @param tokens the user's tokens to be stored
+   * @throws Exception if there is an error storing the tokens in Firestore
+   */
+  public void storeToken(String userName, Tokens tokens) throws Exception {
+    ImmutableMap<String, Object> data = ImmutableMap.of(
+        "accessToken", tokens.getAccessToken(),
+        "refreshToken", tokens.getRefreshToken(),
+        "expiryDate", tokens.getExpiryDate());
+    db
+        .collection(USERS_COLLECTION)
+        .document(userName.replace(USERS_PREFIX, ""))
+        .set(data)
+        .get();
+  }
+
+  /**
+   * Retrieves the user's access and refresh tokens from Firestore.
+   * @param userName the user's name
+   * @return an object containing the user's access and refresh tokens or an
+   *     empty optional if the user does not exist in storage
+   * @throws Exception if there is an error retrieving the tokens from Firestore
+   */
+  public Optional<Tokens> getToken(String userName) throws Exception {
+    DocumentSnapshot doc = db
+        .collection(USERS_COLLECTION)
+        .document(userName.replace(USERS_PREFIX, ""))
+        .get()
+        .get();
+    if (doc.exists()) {
+      return Optional.of(new Tokens(
+          doc.getString("accessToken"),
+          doc.getString("refreshToken"),
+          doc.getDate("expiryDate")));
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/OauthFlow.java
+++ b/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/OauthFlow.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.chat.userAuthApp;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.UserCredentials;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.JsonFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Service that handles the OAuth authentication flow. */
+@Component
+public class OauthFlow {
+  private static final Logger logger =
+      Logger.getLogger(OauthFlow.class.getName());
+
+  private static final JsonFactory JSON_FACTORY =
+      GsonFactory.getDefaultInstance();
+
+  private static final Gson GSON = new Gson();
+
+  // Application OAuth credentials.
+  private static final String CLIENT_SECRETS_FILE = "/client_secrets.json";
+
+  // Define the app's authorization scopes.
+  // Note: 'openid' is required to that Google Auth will return a JWT with the
+  // user id, which we can use to validate that the user who granted consent is
+  // the same who requested it (to avoid identity theft).
+  private static final ImmutableList<String> SCOPES = ImmutableList.of(
+    "openid", "https://www.googleapis.com/auth/chat.messages.create");
+
+  private final FirestoreService firestoreService;
+  private final GoogleClientSecrets clientSecrets;
+
+  /** Initializes the Service. */
+  public OauthFlow(FirestoreService firestoreService) throws IOException {
+    this.firestoreService = firestoreService;
+    InputStream is = OauthFlow.class.getResourceAsStream(CLIENT_SECRETS_FILE);
+    clientSecrets =  GoogleClientSecrets.load(
+        JSON_FACTORY, new InputStreamReader(is));
+  }
+
+  /**
+   * Generates the URL to start the OAuth2 authorization flow.
+   * @param userName the name of the user who is requesting the configuration
+   * @param configCompleteRedirectUrl the URL to redirect to after the
+   *     configuration is completed
+   * @return the authorization URL
+   * @throws IOException if there is an error in the oauth flow
+   * @throws GeneralSecurityException if there is an error in the oauth flow
+   */
+  public String getAuthorizationUrl(
+        String userName, String configCompleteRedirectUrl)
+        throws GeneralSecurityException, IOException  {
+    GoogleAuthorizationCodeFlow flow = newFlow();
+    ImmutableMap<String, String> stateMap = ImmutableMap.of(
+        "userName", userName,
+        "configCompleteRedirectUrl", configCompleteRedirectUrl);
+    String state =
+        Base64.getUrlEncoder().encodeToString(GSON.toJson(stateMap).getBytes());
+    return flow
+        .newAuthorizationUrl()
+        .setState(state)
+        .setRedirectUri(clientSecrets.getDetails().getRedirectUris().get(0))
+        .build();
+  }
+
+  /**
+   * Creates a Google Auth Credentials object from the stored user tokens.
+   * @param tokens the user OAuth tokens
+   * @return a Credentials object to use with Google APIs.
+   */
+  public UserCredentials createUserCredentials(Tokens tokens) {
+    return UserCredentials
+        .newBuilder()
+        .setAccessToken(new AccessToken(
+            tokens.getAccessToken(), tokens.getExpiryDate()))
+        .setRefreshToken(tokens.getRefreshToken())
+        .setClientId(clientSecrets.getDetails().getClientId())
+        .setClientSecret(clientSecrets.getDetails().getClientSecret())
+        .build();
+  }
+
+  /**
+   * Handles a request to complete the oauth callback.
+   * @param error the value of the <code>error</code> request parameter
+   * @param code the value of the <code>code</code> request parameter
+   * @param state the value of the <code>state</code> request parameter
+   * @return the URL to redirect to after the OAuth2 flow is completed
+   * @throws Exception if there is an error completing the oauth flow
+   */
+  public String oauth2callback(
+        Optional<String> error, Optional<String> code, Optional<String> state)
+        throws Exception {
+    // Handle the OAuth 2.0 server response.
+    if (error.isPresent()) {
+      // An error response e.g. error=access_denied.
+      logger.warning("Error: " + error.get());
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Error: " + error.get());
+    }
+
+    // Get access and refresh tokens.
+    if (code.isEmpty()) {
+      logger.warning("Missing token code in the request.");
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Missing token code in the request.");
+    }
+    GoogleAuthorizationCodeFlow flow = newFlow();
+    GoogleTokenResponse tokenResponse = flow
+        .newTokenRequest(code.get())
+        .setRedirectUri(clientSecrets.getDetails().getRedirectUris().get(0))
+        .execute();
+    Date expiryDate = new Date();
+    expiryDate.setTime(
+        expiryDate.getTime() + (tokenResponse.getExpiresInSeconds() * 1000));
+    GoogleIdToken idToken =
+        GoogleIdToken.parse(JSON_FACTORY, tokenResponse.getIdToken());
+    String userId = idToken.getPayload().getSubject();
+
+    // Save tokens to the database so the app can use them to make API calls.
+    firestoreService.storeToken(
+        userId,
+        new Tokens(
+            tokenResponse.getAccessToken(),
+            tokenResponse.getRefreshToken(),
+            expiryDate));
+
+    // Read the state with the userName and configCompleteRedirectUrl from the
+    // provided state.
+    if (state.isEmpty()) {
+      logger.warning("Missing state in the request.");
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Missing state in the request.");
+    }
+    JsonObject stateMap;
+    try {
+      String stateJson = new String(Base64.getUrlDecoder().decode(state.get()));
+      stateMap = JsonParser.parseString(stateJson).getAsJsonObject();
+    } catch (IllegalArgumentException | JsonParseException e) {
+      logger.warning("Error: Invalid request state: " + state.get());
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Error: Invalid request state.");
+    }
+
+    // Validate that the user who granted consent is the same who requested it.
+    String userName = stateMap.get("userName").getAsString();
+    if (!userName.equals("users/" + userId)) {
+      logger.warning("Error: token user does not correspond to request user.");
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN,
+          "Error: the user who granted consent does not correspond to the " +
+          " user who initiated the request. Please start the configuration" +
+          " again and use the same account you're using in Google Chat.");
+    }
+
+    // Redirect to the URL that tells Google Chat that the configuration is
+    // completed.
+    return stateMap.get("configCompleteRedirectUrl").getAsString();
+  }
+
+  private GoogleAuthorizationCodeFlow newFlow()
+      throws GeneralSecurityException, IOException  {
+    return new GoogleAuthorizationCodeFlow.Builder(
+        GoogleNetHttpTransport.newTrustedTransport(),
+        JSON_FACTORY,
+        clientSecrets,
+        SCOPES)
+      .setAccessType("offline")
+      .setApprovalPrompt("force")
+      .build();
+  }
+}

--- a/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/RequestVerifier.java
+++ b/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/RequestVerifier.java
@@ -1,0 +1,60 @@
+package com.google.chat.userAuthApp;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/** Utility to verify that an HTTP request was sent by Google Chat. */
+public class RequestVerifier {
+  private static final Logger logger =
+      Logger.getLogger(RequestVerifier.class.getName());
+
+  private static final JsonFactory JSON_FACTORY =
+      GsonFactory.getDefaultInstance();
+
+  // Bearer Tokens received by Chat apps will always specify this issuer.
+  private static final String CHAT_ISSUER = "chat@system.gserviceaccount.com";
+
+  /**
+   * Verifies that an HTTP request was sent by Google Chat.
+   * @param authorization the value of the Authorization HTTP header
+   * @return <code>>true</code> if the bearer token in the request is valid and
+   *     sent by Google Chat to this server; <code>>false</code> otherwise.
+   */
+  public static boolean verifyGoogleChatRequest(String authorization) {
+    // Extract the signed token sent by Google Chat from the request.
+    String token = authorization.substring(7, authorization.length());
+    // The ID token audience should correspond to the server URl.
+    String audience = ServletUriComponentsBuilder
+        .fromCurrentContextPath()
+        .build()
+        .toUriString()
+        // Chat sends https request but AppEngine acts as a proxy and transforms
+        // it to http. So, the audience should be https.
+        .replace("http:", "https:");
+    logger.info("Audience: " + audience);
+    // Verify valid token, signed by CHAT_ISSUER, intended for this server.
+    try {
+      GoogleIdTokenVerifier verifier =
+          new GoogleIdTokenVerifier
+              .Builder(
+                  GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY)
+              .setAudience(Collections.singletonList(audience))
+              .build();
+      GoogleIdToken idToken = GoogleIdToken.parse(JSON_FACTORY, token);
+      return idToken != null
+          && verifier.verify(idToken)
+          && idToken.getPayload().getEmailVerified()
+          && idToken.getPayload().getEmail().equals(CHAT_ISSUER);
+    } catch (Exception unused) {
+      return false;
+    }
+  }
+}

--- a/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/Tokens.java
+++ b/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/Tokens.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.chat.userAuthApp;
+
+import java.util.Date;
+
+/** A set of OAuth access and refresh tokens for a user. */
+public class Tokens {
+  private final String  accessToken;
+  private final String refreshToken;
+  private final Date expiryDate;
+
+  /** Initializes an instance with the provided tokens. */
+  public Tokens(String accessToken, String refreshToken, Date expiryDate) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.expiryDate = expiryDate;
+  }
+
+  /** Returns the access token. */
+  public String getAccessToken() {
+    return this.accessToken;
+  }
+
+  /** returns the refresh token. */
+  public String getRefreshToken() {
+    return this.refreshToken;
+  }
+
+  /** Returns the expiration date of the access token. */
+  public Date getExpiryDate() {
+    return expiryDate;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this)
+      return true;
+    if (!(o instanceof Tokens))
+      return false;
+    Tokens other = (Tokens) o;
+    boolean accessTokenEquals =
+        (this.accessToken == null && other.accessToken == null)
+        || (this.accessToken != null && this.accessToken.equals(other.accessToken));
+    boolean refreshTokenEquals =
+        (this.refreshToken == null && other.refreshToken == null)
+        || (this.refreshToken != null && this.refreshToken.equals(other.refreshToken));
+    boolean expiryDateEquals =
+        (this.expiryDate == null && other.expiryDate == null)
+        || (this.expiryDate != null && this.expiryDate.equals(other.expiryDate));
+    return accessTokenEquals && refreshTokenEquals && expiryDateEquals;
+  }
+
+  @Override
+  public final int hashCode() {
+    int result = 17;
+    if (accessToken != null) {
+      result = 31 * result + accessToken.hashCode();
+    }
+    if (refreshToken != null) {
+      result = 31 * result + refreshToken.hashCode();
+    }
+    if (expiryDate != null) {
+      result = 31 * result + expiryDate.hashCode();
+    }
+    return result;
+  }
+}

--- a/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/UserAuthPost.java
+++ b/java/user-auth-app/src/main/java/com/google/chat/userAuthApp/UserAuthPost.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.chat.userAuthApp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.chat.v1.ActionResponse;
+import com.google.chat.v1.ChatServiceClient;
+import com.google.chat.v1.ChatServiceSettings;
+import com.google.chat.v1.CreateMessageRequest;
+import com.google.chat.v1.CreateMessageRequest.MessageReplyOption;
+import com.google.chat.v1.Message;
+import com.google.chat.v1.Thread;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Service that posts a message to a Google Chat space using the credentials of
+ * the calling user.
+ */
+@Component
+public class UserAuthPost {
+
+  private final FirestoreService firestoreService;
+  private final OauthFlow oauthFlow;
+
+  /** Initializes the Service. */
+  public UserAuthPost(FirestoreService firestoreService, OauthFlow oauthFlow) {
+    this.firestoreService = firestoreService;
+    this.oauthFlow = oauthFlow;
+  }
+
+  /**
+   * Posts a message to a Google Chat space by calling the Chat API with user
+   * credentials.
+   * The message is posted to the same space as the received event.
+   * If the user has not authorized the app to use their credentials yet,
+   * instead of posting the message, this functions returns a configuration
+   * request to start the OAuth authorization flow.
+   * @param event The event received from Google Chat.
+   * @return An ActionResponse message requesting additional configuration if
+   *     the app needs authorization from the user. Otherwise, an empty object.
+   * @throws Exception if there is a database, authentication, or API failure.
+   */
+  public Message postWithUserCredentials(JsonNode event) throws Exception {
+    String spaceName =
+        event.get("space").get("name").textValue();
+    String userName =
+        event.get("user").get("name").textValue();
+    String displayName =
+        event.get("user").get("displayName").textValue();
+    String text =
+        event.get("message").get("text").textValue();
+    String threadName = event
+        .get("message")
+        .get("thread")
+        .get("name")
+        .textValue();
+
+    // Try to obtain existing OAuth2 tokens from storage.
+    Optional<Tokens> tokens = firestoreService.getToken(userName);
+    if (tokens.isEmpty()) {
+      // App doesn't have tokens for the user yet.
+      // Request configuration to obtain OAuth2 tokens.
+      return getConfigRequest(event);
+    }
+
+    // Create the ChatServiceSettings with the user credentials
+    ChatServiceSettings chatServiceSettings = ChatServiceSettings
+        .newBuilder()
+        .setCredentialsProvider(
+             FixedCredentialsProvider.create(
+                oauthFlow.createUserCredentials(tokens.get())))
+        .build();
+    // Create a Chat message using the Chat API.
+    try (ChatServiceClient chatServiceClient =
+        ChatServiceClient.create(chatServiceSettings)) {
+      CreateMessageRequest request = CreateMessageRequest.newBuilder()
+        // The space to create the message in.
+        .setParent(spaceName)
+        // Respond in the same thread.
+        .setMessageReplyOption(
+            MessageReplyOption.REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD)
+        // The message to create.
+        .setMessage(
+            Message
+                .newBuilder()
+                .setText(String.format("%s said: %s", displayName, text))
+                .setThread(Thread.newBuilder().setName(threadName)))
+        .build();
+      try {
+        // Call Chat API.
+        chatServiceClient.createMessage(request);
+      } catch (ApiException e) {
+        if (e.getStatusCode().getCode().equals(Code.UNAUTHENTICATED)) {
+          // This error probably happened because the user revoked the
+          // authorization. So, let's request configuration again.
+          return getConfigRequest(event);
+        }
+        throw e;
+      }
+    }
+    return Message.getDefaultInstance();
+  }
+
+  /**
+   * Returns an action response that tells Chat to request configuration for the
+   * app. The configuration will be tied to the user who sent the event.
+   * @param event The event received from Google Chat.
+   * @return An ActionResponse message request additional configuration.
+   */
+  private Message getConfigRequest(JsonNode event) throws Exception {
+    String authUrl = oauthFlow.getAuthorizationUrl(
+        event.get("user").get("name").textValue(),
+        event.get("configCompleteRedirectUrl").textValue());
+    return Message.newBuilder().setActionResponse(
+        ActionResponse.newBuilder()
+            .setType(ActionResponse.ResponseType.REQUEST_CONFIG)
+            .setUrl(authUrl))
+        .build();
+  }
+}

--- a/java/user-auth-app/src/main/resources/applicaton.properties
+++ b/java/user-auth-app/src/main/resources/applicaton.properties
@@ -1,0 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set the port to the PORT environment variable
+server.port=${PORT:8080}
+server.error.include-message=always


### PR DESCRIPTION
Add Java User Authorization App sample.

This sample demonstrates how to create a Google Chat app that requests authorization from the user to make calls to Chat API on their behalf. The user tokens are saved on a Firestore database to be reused without having to ask for authorization again.